### PR TITLE
feat: downgrade minimum api level

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![license](https://img.shields.io/badge/license-mit-red?style=for-the-badge)
-![api](https://img.shields.io/badge/api-26+-yellow?style=for-the-badge)
+![api](https://img.shields.io/badge/api-24+-yellow?style=for-the-badge)
 
 <div align="center">
 <br />
@@ -51,6 +51,5 @@ It works with [Material](https://developer.android.com/jetpack/androidx/releases
 - And more...
 
 ## Next Steps
-- Downgrade API Level.
 - Publish the sample on [Google Play Store](https://play.google.com/).
 - [KMM](https://kotlinlang.org/docs/multiplatform-mobile-getting-started.html) Support.

--- a/components/chart/build.gradle
+++ b/components/chart/build.gradle
@@ -7,11 +7,11 @@ apply from: "$rootDir/config/detekt/detekt.gradle"
 
 android {
     namespace 'me.lincolnstuart.funblocks.components.chart'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 24
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -30,11 +30,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 }
 

--- a/components/core/build.gradle
+++ b/components/core/build.gradle
@@ -7,11 +7,11 @@ apply from: "$rootDir/config/detekt/detekt.gradle"
 
 android {
     namespace 'me.lincolnstuart.funblocks.core'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 24
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -31,11 +31,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 }
 

--- a/components/essentials/build.gradle
+++ b/components/essentials/build.gradle
@@ -7,11 +7,11 @@ apply from: "$rootDir/config/detekt/detekt.gradle"
 
 android {
     namespace 'me.lincolnstuart.funblocks.essentials'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 24
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -26,11 +26,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
     buildFeatures {
         compose true

--- a/components/period/build.gradle
+++ b/components/period/build.gradle
@@ -7,11 +7,11 @@ apply from: "$rootDir/config/detekt/detekt.gradle"
 
 android {
     namespace 'me.lincolnstuart.funblocks.period'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
-        minSdk 26
-        targetSdk 33
+        minSdk 24
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -30,15 +30,18 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        coreLibraryDesugaringEnabled = true
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 }
 
 dependencies {
+    coreLibraryDesugaring('com.android.tools:desugar_jdk_libs:2.0.3')
+
     implementation(libs.android.x.core.ktx)
     implementation(libs.android.x.lifecycle.runtime.ktx)
     implementation(libs.bundles.compose)

--- a/foundation/build.gradle
+++ b/foundation/build.gradle
@@ -7,11 +7,11 @@ apply from: "$rootDir/config/detekt/detekt.gradle"
 
 android {
     namespace 'me.lincolnstuart.funblocks.foundation'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 24
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -26,11 +26,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
     buildFeatures {
         compose true

--- a/playground/build.gradle
+++ b/playground/build.gradle
@@ -7,12 +7,12 @@ apply from: "$rootDir/config/detekt/detekt.gradle"
 
 android {
     namespace 'me.lincolnstuart.funblocks.playground'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "me.lincolnstuart.funblocks.playground"
-        minSdk 26
-        targetSdk 33
+        minSdk 24
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 
@@ -29,11 +29,12 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        coreLibraryDesugaringEnabled = true
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
     buildFeatures {
         compose true
@@ -49,6 +50,8 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring('com.android.tools:desugar_jdk_libs:2.0.3')
+
     implementation(libs.splash.screen)
     implementation(libs.android.x.core.ktx)
     implementation(libs.android.x.lifecycle.runtime.ktx)


### PR DESCRIPTION
## :pencil: Description
Downgrade minimum api level from 26 to 24. 
Upgrade target api level from 33 to 34. 
Upgrade jvm verstion from 1.8 to 11.
Enable Gradle Disugaring on Period project.

### :feet: How this can be tested?
Run app.

### :construction: Issue related
NA

### :camera: Evidences
NA

## :rotating_light: Checklist
- [x] My code follows the style guidelines of this project (KtLint e Detekt).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
